### PR TITLE
Drop meta.group.braces.curly block, fixes #3

### DIFF
--- a/enlightened.tmTheme
+++ b/enlightened.tmTheme
@@ -57,19 +57,6 @@
     </dict>
     <dict>
       <key>name</key>
-      <string>meta.group.braces.curly</string>
-      <key>scope</key>
-      <string>meta.group.braces.curly</string>
-      <key>settings</key>
-      <dict>
-        <key>background</key>
-        <string>#FF44AA</string>
-        <key>foreground</key>
-        <string>#3399FF</string>
-      </dict>
-    </dict>
-    <dict>
-      <key>name</key>
       <string>bracket.square</string>
       <key>scope</key>
       <string>bracket.square</string>


### PR DESCRIPTION
I've never edited a theme before, so there may be a better way of doing this, but it seems to work fine. I assume some posh curly braces somewhere just lost their style.
